### PR TITLE
Added ability to get thread numbers

### DIFF
--- a/agency/detail/concurrency/thread_pool.hpp
+++ b/agency/detail/concurrency/thread_pool.hpp
@@ -17,8 +17,6 @@
 #include <algorithm>
 #include <memory>
 #include <future>
-
-//Added unordered maps to allow thread ID lookup
 #include <unordered_map>
 
 
@@ -91,7 +89,7 @@ class thread_pool
       }
     }
 
-    //public function used to get the thread id 
+    //public function used to get the thread number
     inline int get_thread_num(){
       return thread_map_[std::this_thread::get_id()];
     }


### PR DESCRIPTION
Hey Jared,

I have been working with @Dannnno and @alobb on a school project in which we needed to implement a reducer, which requires mapping each thread we use to an integer. We tried to  implement this in our project but it required using a lot of locks which slowed down our program significantly. We were able to efficiently implement this inside Agency by adding an unordered map to the thread pool class, initialize the map in the constructor after the threads_ vector is populated and then add a public member function called get_thread_num() which returns the integer corresponding to the current thread. This has similar functionality to open MP's get thread num and we think this could be useful to other users. Let us know what you think.