### PR TITLE
Added cuda heterogeneous allocator comparators

### DIFF
--- a/agency/cuda/memory/allocator/heterogeneous_allocator.hpp
+++ b/agency/cuda/memory/allocator/heterogeneous_allocator.hpp
@@ -37,6 +37,23 @@ class heterogeneous_allocator : public agency::detail::allocator_adaptor<T,heter
     {}
 }; // end heterogeneous_allocator
 
+template <typename T, typename U, typename HostResource, typename DeviceResource>
+inline bool operator == (const heterogeneous_allocator<T,HostResource,DeviceResource>&, const heterogeneous_allocator<U,HostResource,DeviceResource>&)
+{
+      return true;
+}
+
+template <typename T, typename U, typename HostResource1, typename DeviceResource1, typename HostResource2, typename DeviceResource2>
+inline bool operator == (const heterogeneous_allocator<T,HostResource1,DeviceResource1>&, const heterogeneous_allocator<U,HostResource2,DeviceResource2>&)
+{
+      return false;
+}
+
+template <typename T, typename U, typename HostResource1, typename DeviceResource1, typename HostResource2, typename DeviceResource2>
+inline bool operator != (const heterogeneous_allocator<T,HostResource1,DeviceResource1>& a, const heterogeneous_allocator<U,HostResource2,DeviceResource2>& b)
+{
+      return !(a == b);
+}
 
 } // end cuda
 } // end agency


### PR DESCRIPTION
Added cuda allocators compare operators to resolve an error generated by the following program

```c++
#include <agency/agency.hpp>
#include <agency/cuda.hpp>

#include <cstdlib>
#include <vector>

std::future<std::vector<float,agency::cuda::allocator<float>>>
test(void)
{
    return agency::bulk_async(agency::seq(1), [&](agency::sequenced_agent& self) -> agency::single_result<std::vector<float,agency::cuda::allocator<float>>> {
            return std::vector<float,agency::cuda::allocator<float>>(10);
        });
}

int main()
{
    auto a = test().get();

    return EXIT_SUCCESS;
}
```

Error:
```shell
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/stl_vector.h(1467): error: no operator "==" matches these operands
            operand types are: agency::cuda::heterogeneous_allocator<float, agency::detail::globally_cached_resource<agency::cuda::managed_resource>, agency::detail::malloc_resource> == agency::cuda::heterogeneous_allocator<float, agency::detail::globally_cached_resource<agency::cuda::managed_resource>, agency::detail::malloc_resource>

```