### PR TITLE
Eliminate execution space specifiers from defaulted functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ TODO
 
 ## New Features
 
+  * `require` and properties:
+    * `bulk`
+    * `single`
+    * `then`
+    * `always_blocking`
+
 ### Control Structures
 
 TODO
@@ -67,9 +73,13 @@ TODO
 
 TODO
 
+  * [#437](../../issues/437) Nvcc emits warnings regarding standard library functions calling `__host__`-only functions
+
 ## Resolved Issues
 
 TODO
+
+  * [#428](../../issues/428) Warnings regarding ignored CUDA annotations have been eliminated
 
 ## Acknowledgments
 

--- a/agency/coordinate/detail/named_array.hpp
+++ b/agency/coordinate/detail/named_array.hpp
@@ -19,10 +19,8 @@ struct named_array_element;
 template<class T>
 struct named_array_element<T,0>
 {
-  __AGENCY_ANNOTATION
   named_array_element() = default;
 
-  __AGENCY_ANNOTATION
   named_array_element(const named_array_element&) = default;
 
   __AGENCY_ANNOTATION
@@ -34,10 +32,8 @@ struct named_array_element<T,0>
 template<class T>
 struct named_array_element<T,1>
 {
-  __AGENCY_ANNOTATION
   named_array_element() = default;
 
-  __AGENCY_ANNOTATION
   named_array_element(const named_array_element&) = default;
 
   __AGENCY_ANNOTATION
@@ -49,10 +45,8 @@ struct named_array_element<T,1>
 template<class T>
 struct named_array_element<T,2>
 {
-  __AGENCY_ANNOTATION
   named_array_element() = default;
 
-  __AGENCY_ANNOTATION
   named_array_element(const named_array_element&) = default;
 
   __AGENCY_ANNOTATION
@@ -64,10 +58,8 @@ struct named_array_element<T,2>
 template<class T>
 struct named_array_element<T,3>
 {
-  __AGENCY_ANNOTATION
   named_array_element() = default;
 
-  __AGENCY_ANNOTATION
   named_array_element(const named_array_element&) = default;
 
   __AGENCY_ANNOTATION
@@ -83,10 +75,8 @@ struct named_array_base;
 template<class T, size_t... Indices>
 struct named_array_base<T, index_sequence<Indices...>> : named_array_element<T,Indices>...
 {
-  __AGENCY_ANNOTATION
   named_array_base() = default;
 
-  __AGENCY_ANNOTATION
   named_array_base(const named_array_base&) = default;
 
   __AGENCY_ANNOTATION
@@ -112,10 +102,8 @@ struct named_array : named_array_base<T,make_index_sequence<N>>
   using iterator = pointer;
   using const_iterator = const_pointer;
 
-  __AGENCY_ANNOTATION
   named_array() = default;
 
-  __AGENCY_ANNOTATION
   named_array(const named_array&) = default;
 
   __AGENCY_ANNOTATION

--- a/agency/coordinate/lattice.hpp
+++ b/agency/coordinate/lattice.hpp
@@ -99,11 +99,9 @@ class lattice
     using index_type = decltype(value_type{} - value_type{});
 
     // XXX should create a grid empty of points
-    __AGENCY_ANNOTATION
     lattice() = default;
 
     // copy from
-    __AGENCY_ANNOTATION
     lattice(const lattice&) = default;
 
     // creates a new lattice with min as the first lattice point

--- a/agency/coordinate/point.hpp
+++ b/agency/coordinate/point.hpp
@@ -73,11 +73,9 @@ class point : public agency::detail::point_base_t<T,Rank>,
     using typename super_t::const_pointer;
 
 
-    __AGENCY_ANNOTATION
     point() = default;
 
 
-    __AGENCY_ANNOTATION
     point(const point &) = default;
 
 

--- a/agency/cuda/detail/future/async_future.hpp
+++ b/agency/cuda/detail/future/async_future.hpp
@@ -97,7 +97,6 @@ class async_future
     detail::asynchronous_state<T> state_;
 
   public:
-    __host__ __device__
     async_future() = default;
 
     __host__ __device__

--- a/agency/cuda/detail/future/deferred_future.hpp
+++ b/agency/cuda/detail/future/deferred_future.hpp
@@ -86,13 +86,10 @@ class deferred_function<Result(Args...)>
     }
 
   public:
-    __AGENCY_ANNOTATION
     deferred_function() = default;
 
-    __AGENCY_ANNOTATION
     deferred_function(deferred_function&& other) = default;
 
-    __AGENCY_ANNOTATION
     deferred_function& operator=(deferred_function&& other) = default;
 
     template<class Function>
@@ -452,10 +449,8 @@ class deferred_state
     }
 
   public:
-    __AGENCY_ANNOTATION
     deferred_state() = default;
 
-    __AGENCY_ANNOTATION
     deferred_state(deferred_state&&) = default;
 
     template<class U,
@@ -496,7 +491,6 @@ class deferred_state
     {
     }
 
-    __AGENCY_ANNOTATION
     deferred_state& operator=(deferred_state&& other) = default;
 
     __AGENCY_ANNOTATION
@@ -619,13 +613,10 @@ template<class T>
 class deferred_future
 {
   public:
-    __AGENCY_ANNOTATION
     deferred_future() = default;
 
-    __AGENCY_ANNOTATION
     deferred_future(deferred_future&&) = default;
 
-    __AGENCY_ANNOTATION
     deferred_future& operator=(deferred_future&& other) = default;
 
     template<class U,

--- a/agency/cuda/detail/future/future.hpp
+++ b/agency/cuda/detail/future/future.hpp
@@ -30,10 +30,8 @@ class future
     using variant_type = agency::experimental::variant<agency::cuda::async_future<T>, agency::cuda::deferred_future<T>, agency::always_ready_future<T>>;
 
   public:
-    __AGENCY_ANNOTATION
     future() = default;
 
-    __AGENCY_ANNOTATION
     future(future&&) = default;
 
     template<class Future,
@@ -87,7 +85,6 @@ class future
       : future(converting_move_construct(std::move(other)))
     {}
 
-    __AGENCY_ANNOTATION
     future& operator=(future&& other) = default;
 
     shared_future<T> share();

--- a/agency/cuda/detail/future/shared_future.hpp
+++ b/agency/cuda/detail/future/shared_future.hpp
@@ -60,20 +60,26 @@ class shared_future
     friend agency::cuda::future<U>& detail::underlying_future(shared_future<U>& future);
 
   public:
+    __agency_exec_check_disable__
     shared_future() = default;
 
+    __agency_exec_check_disable__
     shared_future(const shared_future&) = default;
 
     shared_future(agency::cuda::future<T>&& other)
       : underlying_future_(std::make_shared<agency::cuda::future<T>>(std::move(other)))
     {}
 
+    __agency_exec_check_disable__
     shared_future(shared_future&& other) = default;
 
+    __agency_exec_check_disable__
     ~shared_future() = default;
 
+    __agency_exec_check_disable__
     shared_future& operator=(const shared_future& other) = default;
 
+    __agency_exec_check_disable__
     shared_future& operator=(shared_future&& other) = default;
 
     bool valid() const

--- a/agency/cuda/memory/allocator/heterogeneous_allocator.hpp
+++ b/agency/cuda/memory/allocator/heterogeneous_allocator.hpp
@@ -23,10 +23,8 @@ class heterogeneous_allocator : public agency::detail::allocator_adaptor<T,heter
     using super_t = agency::detail::allocator_adaptor<T,heterogeneous_resource<HostResource,DeviceResource>>;
 
   public:
-    __host__ __device__
     heterogeneous_allocator() = default;
 
-    __host__ __device__
     heterogeneous_allocator(const heterogeneous_allocator&) = default;
 
     template<class U>

--- a/agency/detail/asynchronous_state.hpp
+++ b/agency/detail/asynchronous_state.hpp
@@ -64,7 +64,6 @@ class asynchronous_state
     using pointer = typename storage_type::pointer;
 
     // constructs an invalid state
-    __AGENCY_ANNOTATION
     asynchronous_state() = default;
 
     // constructs an immediately ready state
@@ -100,7 +99,6 @@ class asynchronous_state
       : asynchronous_state(construct_ready, allocator, T{})
     {}
 
-    __AGENCY_ANNOTATION
     asynchronous_state(asynchronous_state&& other) = default;
 
     template<class OtherT,
@@ -114,7 +112,6 @@ class asynchronous_state
       : storage_(std::move(other.storage_))
     {}
 
-    __AGENCY_ANNOTATION
     asynchronous_state& operator=(asynchronous_state&&) = default;
 
     __AGENCY_ANNOTATION
@@ -165,10 +162,8 @@ struct empty_type_ptr
 {
   using element_type = T;
   
-  __AGENCY_ANNOTATION
   empty_type_ptr() = default;
   
-  __AGENCY_ANNOTATION
   empty_type_ptr(const empty_type_ptr&) = default;
   
   template<class U,
@@ -207,10 +202,8 @@ struct empty_type_ptr
 template<>
 struct empty_type_ptr<void> : unit_ptr
 {
-  __AGENCY_ANNOTATION
   empty_type_ptr() = default;
 
-  __AGENCY_ANNOTATION
   empty_type_ptr(const empty_type_ptr&) = default;
 
   // allow copy construction from empty_type_ptr<T>

--- a/agency/detail/factory.hpp
+++ b/agency/detail/factory.hpp
@@ -85,7 +85,6 @@ template<class T>
 class moving_factory
 {
   public:
-    __AGENCY_ANNOTATION
     moving_factory(moving_factory&& other) = default;
 
     // this constructor moves other's value into value_

--- a/agency/detail/iterator/constant_iterator.hpp
+++ b/agency/detail/iterator/constant_iterator.hpp
@@ -19,10 +19,8 @@ class constant_iterator
     using difference_type = std::ptrdiff_t;
     using iterator_category = std::random_access_iterator_tag;
 
-    __AGENCY_ANNOTATION
     constant_iterator() = default;
 
-    __AGENCY_ANNOTATION
     constant_iterator(const constant_iterator&) = default;
 
     __AGENCY_ANNOTATION

--- a/agency/detail/iterator/forwarding_iterator.hpp
+++ b/agency/detail/iterator/forwarding_iterator.hpp
@@ -20,7 +20,6 @@ class forwarding_iterator
     using difference_type = typename std::iterator_traits<Iterator>::difference_type;
     using iterator_category = typename std::iterator_traits<Iterator>::iterator_category;
 
-    __AGENCY_ANNOTATION
     forwarding_iterator() = default;
 
     __AGENCY_ANNOTATION

--- a/agency/detail/iterator/reverse_iterator.hpp
+++ b/agency/detail/iterator/reverse_iterator.hpp
@@ -21,7 +21,6 @@ class reverse_iterator
 
     using iterator_type = Iterator;
 
-    __AGENCY_ANNOTATION
     reverse_iterator() = default;
 
     __AGENCY_ANNOTATION

--- a/agency/detail/tuple/tuple_base.hpp
+++ b/agency/detail/tuple/tuple_base.hpp
@@ -97,7 +97,6 @@ class tuple_base<index_sequence<I...>, Types...>
   : public tuple_leaf<I,Types>...
 {
   public:
-    __AGENCY_ANNOTATION
     tuple_base() = default;
 
 

--- a/agency/detail/tuple/tuple_leaf.hpp
+++ b/agency/detail/tuple/tuple_leaf.hpp
@@ -56,7 +56,6 @@ class tuple_leaf_base
 {
   public:
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     tuple_leaf_base() = default;
 
     __agency_exec_check_disable__
@@ -65,7 +64,6 @@ class tuple_leaf_base
     tuple_leaf_base(U&& arg) : val_(std::forward<U>(arg)) {}
 
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     ~tuple_leaf_base() = default;
 
     __AGENCY_ANNOTATION
@@ -89,7 +87,6 @@ template<class T>
 class tuple_leaf_base<T,true> : public T
 {
   public:
-    __AGENCY_ANNOTATION
     tuple_leaf_base() = default;
 
     template<class U>
@@ -118,7 +115,6 @@ class tuple_leaf : public tuple_leaf_base<T>
 
 
   public:
-    __AGENCY_ANNOTATION
     tuple_leaf() = default;
 
 

--- a/agency/detail/unique_function.hpp
+++ b/agency/detail/unique_function.hpp
@@ -53,7 +53,6 @@ class unique_function<Result(Args...)>
   public:
     using result_type = Result;
 
-    __AGENCY_ANNOTATION
     unique_function() = default;
 
     __AGENCY_ANNOTATION
@@ -61,7 +60,6 @@ class unique_function<Result(Args...)>
       : f_ptr_(nullptr)
     {}
 
-    __AGENCY_ANNOTATION
     unique_function(unique_function&& other) = default;
 
     template<class Function>
@@ -94,7 +92,6 @@ class unique_function<Result(Args...)>
       : f_ptr_(allocate_function_pointer(alloc, std::forward<Function>(f)))
     {}
 
-    __AGENCY_ANNOTATION
     unique_function& operator=(unique_function&& other) = default;
 
     __AGENCY_ANNOTATION
@@ -150,7 +147,6 @@ class unique_function<Result(Args...)>
       mutable Function f_;
 
       __agency_exec_check_disable__
-      __AGENCY_ANNOTATION
       ~callable() = default;
 
       __agency_exec_check_disable__
@@ -213,10 +209,8 @@ class unique_function<Result(Args...)>
     {
       using value_type = T;
 
-      __AGENCY_ANNOTATION
       default_allocator() = default;
 
-      __AGENCY_ANNOTATION
       default_allocator(const default_allocator&) = default;
 
       template<class U>

--- a/agency/execution/execution_agent/detail/basic_execution_agent.hpp
+++ b/agency/execution/execution_agent/detail/basic_execution_agent.hpp
@@ -65,10 +65,8 @@ class basic_execution_agent
     class param_type
     {
       public:
-        __AGENCY_ANNOTATION
         param_type() = default;
 
-        __AGENCY_ANNOTATION
         param_type(const param_type& other) = default;
 
         __AGENCY_ANNOTATION

--- a/agency/execution/execution_agent/detail/execution_group.hpp
+++ b/agency/execution/execution_agent/detail/execution_group.hpp
@@ -93,10 +93,8 @@ class execution_group : public execution_group_base<OuterExecutionAgent>
         typename inner_traits::param_type inner_;
 
       public:
-        __AGENCY_ANNOTATION
         param_type() = default;
 
-        __AGENCY_ANNOTATION
         param_type(const param_type&) = default;
 
         __AGENCY_ANNOTATION

--- a/agency/execution/execution_policy/basic_execution_policy.hpp
+++ b/agency/execution/execution_policy/basic_execution_policy.hpp
@@ -139,7 +139,6 @@ class basic_execution_policy
 
     /// \brief The default constructor default constructs this execution policy's associated executor and parameterization.
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     basic_execution_policy() = default;
 
     /// \brief This constructor constructs a new basic_execution_policy given a parameterization and executor.

--- a/agency/execution/execution_policy/detail/simple_sequenced_policy.hpp
+++ b/agency/execution/execution_policy/detail/simple_sequenced_policy.hpp
@@ -28,7 +28,6 @@ class simple_sequenced_policy
     using param_type = typename execution_agent_traits<execution_agent_type>::param_type;
 
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     simple_sequenced_policy() = default;
 
     __agency_exec_check_disable__

--- a/agency/execution/executor/detail/adaptors/basic_executor_adaptor.hpp
+++ b/agency/execution/executor/detail/adaptors/basic_executor_adaptor.hpp
@@ -78,11 +78,9 @@ class basic_executor_adaptor
     // XXX need to publicize the other executor member typedefs such as execution_category, etc.
 
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     basic_executor_adaptor() = default;
 
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     basic_executor_adaptor(const basic_executor_adaptor&) = default;
 
     __agency_exec_check_disable__

--- a/agency/execution/executor/detail/execution_functions/adaptations/bulk_then_execute_via_bulk_twoway_execute.hpp
+++ b/agency/execution/executor/detail/execution_functions/adaptations/bulk_then_execute_via_bulk_twoway_execute.hpp
@@ -57,7 +57,6 @@ struct functor
   using predecessor_type = future_result_t<SharedFuture>;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ~functor() = default;
 
   __agency_exec_check_disable__
@@ -67,7 +66,6 @@ struct functor
   {}
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   functor(const functor&) = default;
 
   __agency_exec_check_disable__
@@ -91,7 +89,6 @@ struct functor<Function,SharedFuture,true>
   mutable SharedFuture fut_;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ~functor() = default;
 
   __agency_exec_check_disable__
@@ -101,7 +98,6 @@ struct functor<Function,SharedFuture,true>
   {}
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   functor(const functor&) = default;
 
   __agency_exec_check_disable__

--- a/agency/execution/executor/detail/utility/invoke_functors.hpp
+++ b/agency/execution/executor/detail/utility/invoke_functors.hpp
@@ -18,15 +18,12 @@ struct ignore_unit_result_parameter_and_invoke
   mutable Function f;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ignore_unit_result_parameter_and_invoke() = default;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ignore_unit_result_parameter_and_invoke(const ignore_unit_result_parameter_and_invoke&) = default;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ~ignore_unit_result_parameter_and_invoke() = default;
 
   template<class Index, class... SharedParameters>
@@ -44,15 +41,12 @@ struct ignore_unit_result_parameter_and_invoke<Function,void>
   mutable Function f;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ignore_unit_result_parameter_and_invoke() = default;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ignore_unit_result_parameter_and_invoke(const ignore_unit_result_parameter_and_invoke&) = default;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ~ignore_unit_result_parameter_and_invoke() = default;
 
   template<class Index, class... SharedParameters>

--- a/agency/execution/executor/executor_array.hpp
+++ b/agency/execution/executor/executor_array.hpp
@@ -58,11 +58,9 @@ class executor_array
     }
 
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     executor_array() = default;
 
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     executor_array(const executor_array&) = default;
 
     __agency_exec_check_disable__

--- a/agency/execution/executor/properties/then.hpp
+++ b/agency/execution/executor/properties/then.hpp
@@ -53,7 +53,6 @@ class then_executor : public basic_executor_adaptor<Executor>
     using super_t = basic_executor_adaptor<Executor>;
 
   public:
-    __AGENCY_ANNOTATION
     then_executor() = default;
 
     __AGENCY_ANNOTATION

--- a/agency/execution/executor/variant_executor.hpp
+++ b/agency/execution/executor/variant_executor.hpp
@@ -72,10 +72,8 @@ class variant_executor
       executor_allocator_t<Executors,T>...
     >;
 
-    __AGENCY_ANNOTATION
     variant_executor() = default;
 
-    __AGENCY_ANNOTATION
     variant_executor(const variant_executor& other) = default;
 
     template<class OtherExecutor,

--- a/agency/experimental/bounded_integer.hpp
+++ b/agency/experimental/bounded_integer.hpp
@@ -25,10 +25,8 @@ class bounded_integer
 
     static const value_type static_bound = bound;
 
-    __AGENCY_ANNOTATION
     constexpr bounded_integer() = default;
 
-    __AGENCY_ANNOTATION
     constexpr bounded_integer(const bounded_integer&) = default;
 
     // if number > bound, the value of the bounded_integer is undefined
@@ -56,7 +54,6 @@ class bounded_integer
     }
 
     // operator members follow
-    __AGENCY_ANNOTATION
     bounded_integer& operator=(const bounded_integer&) = default;
 
     // assign

--- a/agency/experimental/ndarray/ndarray_ref.hpp
+++ b/agency/experimental/ndarray/ndarray_ref.hpp
@@ -47,7 +47,6 @@ class basic_ndarray_ref
     __AGENCY_ANNOTATION
     basic_ndarray_ref() : basic_ndarray_ref(nullptr) {}
 
-    __AGENCY_ANNOTATION
     basic_ndarray_ref(const basic_ndarray_ref&) = default;
 
     template<class OtherT,

--- a/agency/experimental/ranges/chunk.hpp
+++ b/agency/experimental/ranges/chunk.hpp
@@ -167,7 +167,6 @@ class chunk_view
   public:
     using difference_type = Difference;
 
-    __AGENCY_ANNOTATION
     chunk_view() = default;
 
     __AGENCY_ANNOTATION

--- a/agency/experimental/ranges/flatten.hpp
+++ b/agency/experimental/ranges/flatten.hpp
@@ -33,10 +33,8 @@ class flatten_view
     using value_type = range_value_t<inner_range_type>;
     using reference = range_reference_t<inner_range_type>;
 
-    __AGENCY_ANNOTATION
     flatten_view() = default;
 
-    __AGENCY_ANNOTATION
     flatten_view(const flatten_view&) = default;
 
     template<class OtherRangeOfRanges,

--- a/agency/experimental/ranges/iota.hpp
+++ b/agency/experimental/ranges/iota.hpp
@@ -26,10 +26,8 @@ class counting_iterator
     //     otherwise it should defer to iterator_traits
     using iterator_category = std::random_access_iterator_tag;
 
-    __AGENCY_ANNOTATION
     counting_iterator() = default;
 
-    __AGENCY_ANNOTATION
     counting_iterator(const counting_iterator&) = default;
 
     __AGENCY_ANNOTATION

--- a/agency/experimental/ranges/statically_bounded.hpp
+++ b/agency/experimental/ranges/statically_bounded.hpp
@@ -32,10 +32,8 @@ class statically_bounded_view
     // note the special size_type
     using size_type = bounded_size_t<bound>;
 
-    __AGENCY_ANNOTATION
     statically_bounded_view() = default;
 
-    __AGENCY_ANNOTATION
     statically_bounded_view(const statically_bounded_view&) = default;
 
     template<class OtherRange,

--- a/agency/experimental/ranges/untile.hpp
+++ b/agency/experimental/ranges/untile.hpp
@@ -37,10 +37,8 @@ class small_untiled_view
     using value_type = range_value_t<tile_type>;
     using reference = range_reference_t<tile_type>;
 
-    __AGENCY_ANNOTATION
     small_untiled_view() = default;
 
-    __AGENCY_ANNOTATION
     small_untiled_view(const small_untiled_view&) = default;
 
     template<class OtherRangeOfRanges,

--- a/agency/experimental/ranges/zip_with.hpp
+++ b/agency/experimental/ranges/zip_with.hpp
@@ -358,10 +358,8 @@ class zip_with_view
       range_sentinel_t<Ranges>...
     >;
 
-    __AGENCY_ANNOTATION
     zip_with_view() = default;
 
-    __AGENCY_ANNOTATION
     zip_with_view(const zip_with_view& other) = default;
 
     template<class OtherRange, class... OtherRanges,

--- a/agency/experimental/short_vector.hpp
+++ b/agency/experimental/short_vector.hpp
@@ -166,10 +166,8 @@ class short_vector
     {
     }
 
-    __AGENCY_ANNOTATION
     short_vector(const short_vector&) = default;
 
-    __AGENCY_ANNOTATION
     short_vector(short_vector&&) = default;
 
     template<class Range>

--- a/agency/future/always_ready_future.hpp
+++ b/agency/future/always_ready_future.hpp
@@ -53,7 +53,6 @@ class always_ready_future
   public:
     // Default constructor creates an invalid always_ready_future
     // Postcondition: !valid()
-    __AGENCY_ANNOTATION
     always_ready_future() = default;
 
     __AGENCY_ANNOTATION

--- a/agency/future/variant_future.hpp
+++ b/agency/future/variant_future.hpp
@@ -31,10 +31,8 @@ class variant_future
     static_assert(detail::conjunction<is_future<Future>, is_future<Futures>...>::value, "All of variant_future's template parmeter types must be Futures.");
     static_assert(detail::conjunction<std::is_same<result_type, future_result_t<Futures>>...>::value, "All Futures' result types must be the same.");
 
-    __AGENCY_ANNOTATION
     variant_future() = default;
 
-    __AGENCY_ANNOTATION
     variant_future(variant_future&&) = default;
 
     template<class OtherFuture,
@@ -46,7 +44,6 @@ class variant_future
       : variant_(std::forward<OtherFuture>(other))
     {}
 
-    __AGENCY_ANNOTATION
     variant_future& operator=(variant_future&& other) = default;
 
     // this is the overload of make_ready() for non-void result_type

--- a/agency/memory/allocator/allocator.hpp
+++ b/agency/memory/allocator/allocator.hpp
@@ -32,10 +32,8 @@ struct allocator
   using propagate_on_container_move_assignment = std::true_type;
   using is_always_equal = std::true_type;
 
-  __AGENCY_ANNOTATION
   allocator() = default;
 
-  __AGENCY_ANNOTATION
   allocator(const allocator&) = default;
 
   template<class U>

--- a/agency/memory/allocator/detail/allocator_adaptor.hpp
+++ b/agency/memory/allocator/detail/allocator_adaptor.hpp
@@ -22,11 +22,9 @@ class allocator_adaptor : private MemoryResource
     using value_type = T;
 
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     allocator_adaptor() = default;
 
     __agency_exec_check_disable__
-    __AGENCY_ANNOTATION
     allocator_adaptor(const allocator_adaptor&) = default;
 
     __agency_exec_check_disable__

--- a/agency/memory/allocator/detail/any_allocator.hpp
+++ b/agency/memory/allocator/detail/any_allocator.hpp
@@ -61,11 +61,9 @@ template<class Allocator>
 struct concrete_allocator : abstract_allocator
 {
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   concrete_allocator(const concrete_allocator& other) = default;
 
   __agency_exec_check_disable__
-  __AGENCY_ANNOTATION
   ~concrete_allocator() = default;
 
   __agency_exec_check_disable__

--- a/agency/memory/allocator/variant_allocator.hpp
+++ b/agency/memory/allocator/variant_allocator.hpp
@@ -28,10 +28,8 @@ class variant_allocator
       >;
     };
 
-    __AGENCY_ANNOTATION
     variant_allocator() = default;
 
-    __AGENCY_ANNOTATION
     variant_allocator(const variant_allocator&) = default;
 
   public:

--- a/testing/execution/executor/cuda/variant_executor.cu
+++ b/testing/execution/executor/cuda/variant_executor.cu
@@ -52,11 +52,9 @@ struct return_container
   {}
 
   __agency_exec_check_disable__
-  __host__ __device__
   return_container(const return_container&) = default;
 
   __agency_exec_check_disable__
-  __host__ __device__
   ~return_container() = default;
 
   __host__ __device__

--- a/testing/future/cuda/async_future/make_nonvoid_async_future.cu
+++ b/testing/future/cuda/async_future/make_nonvoid_async_future.cu
@@ -35,7 +35,6 @@ struct my_allocator
 
   agency::cuda::allocator<T> alloc;
 
-  __AGENCY_ANNOTATION
   my_allocator() = default;
 
   template<class U>


### PR DESCRIPTION
Fixes #428