### PR TITLE
Improving tuple initialization -- N4387

### DIFF
--- a/agency/tuple.hpp
+++ b/agency/tuple.hpp
@@ -38,9 +38,19 @@ class tuple
     __AGENCY_ANNOTATION
     tuple() : base_{} {};
 
+    template<class... UTypes,
+             __AGENCY_REQUIRES(
+               (sizeof...(Types) == sizeof...(UTypes)) &&
+               detail::conjunction<
+                 std::is_constructible<Types,UTypes&&>...
+               >::value &&
+               detail::conjunction<
+                 std::is_convertible<UTypes&&,Types>...
+               >::value
+             )>
     __AGENCY_ANNOTATION
-    explicit tuple(const Types&... args)
-      : base_{args...}
+    tuple(UTypes&&... args)
+      : base_{std::forward<UTypes>(args)...}
     {}
 
     template<class... UTypes,
@@ -48,6 +58,10 @@ class tuple
                (sizeof...(Types) == sizeof...(UTypes)) &&
                detail::conjunction<
                  std::is_constructible<Types,UTypes&&>...
+               >::value &&
+               not
+               detail::disjunction<
+                 std::is_convertible<UTypes&&,Types>...
                >::value
              )>
     __AGENCY_ANNOTATION


### PR DESCRIPTION
I apply the N4387 pattern to the direct and converting constructor of `agency::tuple` to allow implicit construction of `agency::tuple` when all elements are implicitly constructible.

This allows the following, which would not be allowed previously:

`agency::tuple<int, char> do_stuff() 
{ 
return {1, 'c'}; 
}`

`agency::tuple<int, int> a = {1,2};`

`void more_stuff(const agency::tuple<int, char>& v) { ... }`
`more_stuff({4,'z'});`

N4387 also makes the converting copy/move-constructors and pair copy/move-constructors conditionally explicit which would add additional safety to `agency::tuple`, but this is not included in this pull request.